### PR TITLE
Copy from node-build with code-coverage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,41 @@
 root = true
 
 [*]
-indent_style = space
-indent_size = 4
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+indent_size = 8
+
+[{deps,tools,build}/**]
+indent_style = ignore
+indent_size = ignore
+end_of_line = ignore
+trim_trailing_whitespace = ignore
+charset = ignore
+
+[{test/fixtures,deps,build,tools/eslint,tools/gyp,tools/icu,tools/msvs}/**]
 insert_final_newline = false
+
+# .NET Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+publish/
+build/Release
+coverage
+lib-cov
+
+# deps
+node_modules/
+__pycache__/
+
+# Logs
+logs
+*.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+
+# Mac files
+.DS_Store
+
+# randoms
+*.pyc
+dbdata
+old
+yarn-error.log
+dist
+*/test-results

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,31 @@
-FROM ubuntu:18.04
+FROM node:14.15.4-buster
 
-# Adding sources and updating
-#RUN echo "" > /etc/apt/sources.list \
-#    && apt-get update
+# install Chromium for (unit)-testing during build-phase
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends 'chromium=87.0.4280.88-0.4~deb10u1' && \
+    rm -rf /var/lib/apt/lists/*
 
+# install Firefox for (unit)-testing during build-phase
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends 'firefox-esr=78.6.1esr-1~deb10u1' && \
+    rm -rf /var/lib/apt/lists/*
 
-# Installing base software
-RUN apt-get update \
-	&& apt-get install -y curl apt-transport-https gnupg wget dpkg 
+# install sonar-scanner 
+ENV SONAR_VERSION="4.5.0.2216-linux"
+COPY sonar-scanner-cli-$SONAR_VERSION.zip /var/opt/
+RUN unzip /var/opt/sonar-scanner-cli-$SONAR_VERSION.zip -d /var/opt && \
+    rm /var/opt/sonar-scanner-cli-$SONAR_VERSION.zip
+ENV PATH="$PATH:/var/opt/sonar-scanner-$SONAR_VERSION/bin"
 
+# copy build scripts into container
+RUN mkdir /code
+WORKDIR /code
+COPY entrypoint.sh /entrypoint.sh
+COPY front-end-build.sh /front-end-build.sh
+
+# set execute on the scripts
+RUN chmod +x /entrypoint.sh && \
+    chmod +x /front-end-build.sh 
+
+# start the build
+CMD [ "bash", "/entrypoint.sh" ] 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,48 @@
+# bitbucket-pipelines front-end-build
+
 [![logo](./logo.jpg)](https://inforit.nl)
 
-# base
+Docker image to automate front-end builds on bitbucket (and local)
 
-Our base docker image
+Comes preinstalled with Firefox and Chromium for (unit)-testing during build.
+Also sonar-scanner is installed to enable sonar analyzing 
 
-# Instructions:
+## Instructions
 
 1. update dockerfile
 2. build local version:
 
+    ```sh
+    npm run build
     ```
-    docker build -t inforitnl/imagename .
-    ```
+
 3. push new version to dockerhub:
 
+    ```sh
+    npm run push
     ```
-    docker push inforitnl/imagename:latest
-    ```
+
 4. tag and push again (optional but recommended):
 
+    ```sh
+    npm run publish
     ```
-    docker tag inforitnl/imagename inforitnl/imagename:1
-    docker push inforitnl/imagename:1
-    ```
 
-# Usage
+## Usage
 
+```sh
+image: inforitnl/front-end-build
+
+pipelines:
+  default:
+    - step:
+        script:
+          - /front-end-build.sh
 ```
-FROM inforitnl/base
 
+## scripts
 
-```
+| Command | Description                         |
+| ------- | ----------------------------------- |
+| build   | build the container with latest tag |
+| push    | pushes the container                |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/front-end-build.sh

--- a/front-end-build.sh
+++ b/front-end-build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# return failing exit code if any command fails
+set -e
+
+# enable nullglob - allows filename patterns which match no files to expand to a null string, rather than themselves
+shopt -s nullglob
+
+DIST="./dist"
+
+# go to the workdir
+if [ -n "$BITBUCKET_CLONE_DIR" ]
+then
+    cd "$BITBUCKET_CLONE_DIR" || return
+else
+    cd /code || return
+fi
+
+# Add myget npm source if access token is set
+if [ -n "$MYGET_ACCESS_TOKEN" ]
+then
+    # check whether inforit scope exists, if not add it
+    if [[ $(cat ~/.npmrc | grep @inforit | wc -l) -eq "0" ]]; then
+        echo -e "\n@inforit:registry=https://www.myget.org/F/inforit/npm/\n//www.myget.org/F/inforit/npm/:_authToken=$MYGET_ACCESS_TOKEN" >> ~/.npmrc
+        echo "@inforit scope sucesfully registered"
+    else
+        echo "@inforit scope already registered"
+    fi
+fi
+
+rm -rf "$DIST"
+
+npm install
+npm run build:prod
+npm run test:prod
+npm run zipdist

--- a/front-end-build.sh
+++ b/front-end-build.sh
@@ -30,6 +30,6 @@ fi
 rm -rf "$DIST"
 
 npm install
-npm run build:prod
-npm run test:prod
-npm run zipdist
+npm run build:prod --if-present
+npm run test:prod --if-present
+npm run zipdist --if-present

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "front-end-build",
+    "version": "1.0.0",
+    "description": "[![logo](./logo.jpg)](https://inforit.nl)",
+    "main": "index.js",
+    "scripts": {
+        "build": "docker build -t inforitnl/front-end-build .",
+        "tag": "docker tag inforitnl/front-end-build",
+        "push": "docker push inforitnl/front-end-build",
+        "publish": "DOCKER_PROD_TAG=$(cat package.json | grep version | head -1  | awk -F: '{ print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]') && docker build -t inforitnl/front-end-build . && docker tag inforitnl/front-end-build inforitnl/front-end-build:latest && docker tag inforitnl/front-end-build inforitnl/front-end-build:$DOCKER_PROD_TAG  && docker push inforitnl/front-end-build:latest && docker push inforitnl/front-end-build:$DOCKER_PROD_TAG "
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Inforitnl/front-end-build.git"
+    },
+    "author": "Rick van Lieshout <info@rickvanlieshout.com> (http://rickvanlieshout.com)",
+    "license": "ISC",
+    "bugs": {
+        "url": "https://github.com/Inforitnl/front-end-build/issues"
+    },
+    "homepage": "https://github.com/Inforitnl/front-end-build#readme"
+}


### PR DESCRIPTION
Attempt 2 for codecoverage, this time non-breaking:

Copy of node-build renamed to front-end-build
Upgrade to latest stable debian image: buster
Added browsers and sonar-scanner to docker image
Add npm test:prod