### PR TITLE
Set from image back to node 16.20 becuase of compatibility with nodegit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19.7-bullseye-slim
+FROM node:16.20.0-buster-slim
 
 # install build dependencies
 RUN apt-get update && \


### PR DESCRIPTION
Because nodegit hasn't a version that is compatible with node 19, we are forced to stay at node 16 until we replaced nodegit with something that works with higher node versions