### PR TITLE
feat: downgrade npm version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.0] - 2026-08-17
+
+- Upgraded node to latest active LTS version 24.19.0. Currently we have packages which do not support v25 because it's EOL
+
+## [7.0.0] - 2026-04-21
+
+- Upgraded node to 25.9.0
+
 ## [6.0.0] - 2025-11-03
 
 - Upgraded node to latest active LTS version 22.11.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:25.9.0-bookworm
+FROM node:24.19.0-bookworm
 
 # install build dependencies
 RUN apt-get update && \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "front-end-build",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "[![logo](./logo.jpg)](https://frontliners.nl)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Upgraded node to latest active LTS version 24.19.0. Currently we have packages which do not support v25 because it's EOL